### PR TITLE
Add /time_est

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Additional notes are listed at the end of the command list.
     - Displays the server's local time.
 * **time12**
     - Displays the server's local time in 12 hour format.
+* **time_est**
+    - Displays the local time in EST in 12 hour format.
 * **timer** "length" "timer name" "public"
     - Starts a timer of the given length in seconds, which will send a notification to people in the area once it expires.
     - If given a timer name, it will override the default timer name (OOCNameTimer).

--- a/server/commands.py
+++ b/server/commands.py
@@ -4934,6 +4934,26 @@ def ooc_cmd_time12(client: ClientManager.Client, arg: str):
 
     client.send_ooc(time.strftime('%a %b %e %I:%M:%S %p (%z) %Y'))
 
+def ooc_cmd_time_est(client, arg):
+    """
+    Return the current server date and time in Eastern Standard Time.
+
+    SYNTAX
+    /time_est
+
+    PARAMETERS
+    None
+
+    EXAMPLES
+    /time_est         :: May return something like "Sat Apr 27 09:04:47 AM 2019"
+    """
+
+    if len(arg) != 0:
+        raise ArgumentError('This command has no arguments.')
+
+    client.send_ooc((datetime.datetime.utcnow() - datetime.timedelta(hours=5)
+).strftime("%a %b %e %I:%M:%S %p %Y"))
+
 def ooc_cmd_timer(client: ClientManager.Client, arg: str):
     """
     Start a timer.

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -43,10 +43,10 @@ from server.zone_manager import ZoneManager
 class TsuserverDR:
     def __init__(self, protocol=None, client_manager=None, in_test=False):
         self.release = 4
-        self.major_version = 2
-        self.minor_version = 3
-        self.segment_version = 'post1'
-        self.internal_version = '191231b'
+        self.major_version = 3
+        self.minor_version = 0
+        self.segment_version = 'a1'
+        self.internal_version = '200101a'
         version_string = self.get_version_string()
         self.software = 'TsuserverDR {}'.format(version_string)
         self.version = 'TsuserverDR {} ({})'.format(version_string, self.internal_version)


### PR DESCRIPTION
`/time_est` returns the time in EST in 12 hour format. Ex: `Wed Jan 1 08:46:30 PM 2020`.