### PR TITLE
Fix /bg turning lights on in previously dark areas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,3 +368,6 @@
 
 ### 200201a (4.2.3-post5)
 * Fixed /showname_freeze and /showname_nuke causing errors when notifying other users
+
+### 200320a (4.2.3-post6)
+* Fixed /bg turning on lights in previously dark rooms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,3 +365,6 @@
 
 ### 200112b (4.2.3-post4)
 * Fixed players/server being able to load any YAML files with invalid YAML syntax. An informative error message will be returned to assist in fixing said file
+
+### 200201a (4.2.3-post5)
+* Fixed /showname_freeze and /showname_nuke causing errors when notifying members of its execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,4 +367,4 @@
 * Fixed players/server being able to load any YAML files with invalid YAML syntax. An informative error message will be returned to assist in fixing said file
 
 ### 200201a (4.2.3-post5)
-* Fixed /showname_freeze and /showname_nuke causing errors when notifying members of its execution
+* Fixed /showname_freeze and /showname_nuke causing errors when notifying other users

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -522,8 +522,8 @@ class AreaManager:
                     self.background_backup = self.background
                 intended_background = self.server.config['blackout_background']
 
-            self.change_background(intended_background, validate=False) # Allow restoring custom bg.
             self.lights = new_lights
+            self.change_background(intended_background, validate=False) # Allow restoring custom bg.
 
             # Announce light status change
             if initiator: # If a player initiated the change light sequence, send targeted messages

--- a/server/area_manager.py
+++ b/server/area_manager.py
@@ -224,7 +224,11 @@ class AreaManager:
             if validate and bg.lower() not in [name.lower() for name in self.server.backgrounds]:
                 raise AreaError('Invalid background name.')
 
-            self.background = bg
+            if self.lights:
+                self.background = bg
+            else:
+                self.background = self.server.config['blackout_background']
+                self.background_backup = bg
             for c in self.clients:
                 if c.is_blind and not override_blind:
                     c.send_command('BN', self.server.config['blackout_background'])

--- a/server/commands.py
+++ b/server/commands.py
@@ -4671,9 +4671,9 @@ def ooc_cmd_showname_freeze(client: ClientManager.Client, arg: str):
 
     client.send_ooc('You have {} all shownames.'.format(status[client.server.showname_freeze]))
     client.send_ooc_others('A mod has {} all shownames.'
-                           .format(status[client.server.showname_freeze]), is_mod=False)
+                           .format(status[client.server.showname_freeze]), is_staff=False)
     client.send_ooc_others('{} has {} all shownames.'
-                           .format(client.name, status[client.server.showname_freeze]), is_mod=True)
+                           .format(client.name, status[client.server.showname_freeze]), is_staff=True)
     logger.log_server('{} has {} all shownames.'
                       .format(client.name, status[client.server.showname_freeze]), client)
 
@@ -4740,8 +4740,8 @@ def ooc_cmd_showname_nuke(client: ClientManager.Client, arg: str):
             c.change_showname('')
 
     client.send_ooc('You have nuked all shownames.')
-    client.send_ooc_others('A mod has nuked all shownames.', is_mod=False)
-    client.send_ooc_others('{} has nuked all shownames.'.format(client.name), is_mod=True)
+    client.send_ooc_others('A mod has nuked all shownames.', is_staff=False)
+    client.send_ooc_others('{} has nuked all shownames.'.format(client.name), is_staff=True)
     logger.log_server('{} has nuked all shownames.'.format(client.name), client)
 
 def ooc_cmd_showname_set(client: ClientManager.Client, arg: str):

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -45,8 +45,8 @@ class TsuserverDR:
         self.release = 4
         self.major_version = 2
         self.minor_version = 3
-        self.segment_version = 'post5'
-        self.internal_version = '200201a'
+        self.segment_version = 'post6'
+        self.internal_version = '200320a'
         version_string = self.get_version_string()
         self.software = 'TsuserverDR {}'.format(version_string)
         self.version = 'TsuserverDR {} ({})'.format(version_string, self.internal_version)

--- a/server/tsuserver.py
+++ b/server/tsuserver.py
@@ -45,8 +45,8 @@ class TsuserverDR:
         self.release = 4
         self.major_version = 2
         self.minor_version = 3
-        self.segment_version = 'post4'
-        self.internal_version = '200112b'
+        self.segment_version = 'post5'
+        self.internal_version = '200201a'
         version_string = self.get_version_string()
         self.software = 'TsuserverDR {}'.format(version_string)
         self.version = 'TsuserverDR {} ({})'.format(version_string, self.internal_version)


### PR DESCRIPTION
When `/bg` was used in an area with lights that are off, the background would still change to the intended background, thus effectively turning the lights on. This change prevents the background from changing and sets the intended background to `background_backup` for use when the lights turn back on.