### PR TITLE
[AO2 compatibility] Get 2.9.X y-offset working

### DIFF
--- a/server/aoprotocol.py
+++ b/server/aoprotocol.py
@@ -344,7 +344,7 @@ class AOProtocol(asyncio.Protocol):
         self.client.send_command_dict('FL', {
             'fl_ao2_list': ['yellowtext', 'customobjections', 'flipping', 'fastloading',
                             'noencryption', 'deskmod', 'evidence', 'cccc_ic_support', 'looping_sfx',
-                            'additive', 'effects',
+                            'additive', 'effects', 'y_offset',
                             # DRO exclusive stuff
                             'ackMS', 'showname', 'chrini', 'charscheck']
             })

--- a/server/clients.py
+++ b/server/clients.py
@@ -624,7 +624,7 @@ class ClientAO2d9d0(Enum):
         ('color', ArgType.INT),  # 14
         ('showname', ArgType.STR_OR_EMPTY),  # 15
         ('charid_pair_pair_order', ArgType.STR),  # 16
-        ('offset_pair', ArgType.INT),  # 17
+        ('offset_pair', ArgType.STR),  # 17
         ('nonint_pre', ArgType.INT),  # 18
         ('looping_sfx', ArgType.INT),  # 19
         ('screenshake', ArgType.INT),  # 20

--- a/tests/test_client_connection.py
+++ b/tests/test_client_connection.py
@@ -2,7 +2,7 @@ from .structures import _Unittest
 
 _standard_FL = ('yellowtext', 'customobjections', 'flipping', 'fastloading', 'noencryption',
                 'deskmod', 'evidence', 'cccc_ic_support', 'looping_sfx', 'additive', 'effects',
-                'ackMS', 'showname', 'chrini', 'charscheck')
+                'y_offset', 'ackMS', 'showname', 'chrini', 'charscheck')
 
 
 class TestClientConnection(_Unittest):


### PR DESCRIPTION
The 2.9.X y-offset implementation is tested to work with these changes nicely