### PR TITLE
add 2.10 packet support

### DIFF
--- a/server/aoprotocol.py
+++ b/server/aoprotocol.py
@@ -329,7 +329,9 @@ class AOProtocol(asyncio.Protocol):
                     self.client.packet_handler = clients.ClientDRO1d0d0()
             else:  # AO2 protocol
                 if release == 2:
-                    if major >= 9:
+                    if major >= 10:
+                        self.client.packet_handler = clients.ClientAO2d10()
+                    elif major >= 9:
                         self.client.packet_handler = clients.ClientAO2d9d0()
                     elif major >= 8 and minor >= 4:
                         self.client.packet_handler = clients.ClientAO2d8d4()

--- a/server/clients.py
+++ b/server/clients.py
@@ -765,6 +765,19 @@ class ClientAO2d9d0(DefaultDROProtocol):
         ('pos', ''),  # 1
         ]
 
+
+class ClientAO2d10(ClientAO2d9d0):
+    ASKCHAA_INBOUND = []
+
+    RC_INBOUND = []
+
+    RM_INBOUND = []
+
+    RD_INBOUND = []
+
+    ZZ_INBOUND = []
+
+
 class ClientKFO2d8(ClientAO2d7):
     pass
 


### PR DESCRIPTION
2.10 fixes an issue with the packets where no-arg packets are broken